### PR TITLE
Send Statistics and Historical Stats

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,31 @@
+# Description :: User Story
+
+Add an overview of the changes in this pull request.
+
+## Type of Change
+
+- [ ] New Feature
+- [ ] Bug Fix
+- [ ] Refactor
+- [ ] Breaking Change
+- [ ] Testing
+- [ ] Documentation
+
+## Environment and Dependencies
+
+- [ ] Packages Added
+- [ ] Packages Updated
+- [ ] Packages Removed
+- [ ] No Changes
+
+Details:
+
+## Pull Request Notes
+
+Add any notes here.
+
+## Pytest Results and Coverage
+
+```txt
+Paste Coverage.py results here
+```

--- a/tap_ask_nicely/client.py
+++ b/tap_ask_nicely/client.py
@@ -24,3 +24,8 @@ class AskNicelyClient:
         url = f"{self._BASE_URL}/responses/asc/{page_size}/{page}/{start_time_unix}/json/0"
         params = {"X-apikey": self._api_key}
         return self._client.get(url, params=params).json()
+
+    def fetch_sent_statistics(self, rolling_history: int) -> dict:
+        url = f"{self._BASE_URL}/sentstats/{rolling_history}"
+        params = {"X-apikey": self._api_key}
+        return self._client.get(url, params=params).json()

--- a/tap_ask_nicely/client.py
+++ b/tap_ask_nicely/client.py
@@ -29,3 +29,14 @@ class AskNicelyClient:
         url = f"{self._BASE_URL}/sentstats/{rolling_history}"
         params = {"X-apikey": self._api_key}
         return self._client.get(url, params=params).json()
+
+    def fetch_historical_stats(self, date: str) -> dict:
+        url = f"{self._BASE_URL}/stats"
+        date_list = date.split('-')
+        params = {
+            "X-apikey": self._api_key,
+            "year": date_list[0],
+            "month": date_list[1],
+            "day": date_list[2]
+        }
+        return self._client.get(url, params=params).json()

--- a/tap_ask_nicely/client.py
+++ b/tap_ask_nicely/client.py
@@ -3,40 +3,38 @@ from datetime import datetime
 from singer.utils import strptime_to_utc
 
 
-
 class AskNicelyClient:
     def __init__(self, config):
-        self._BASE_URL = f"https://{config['subdomain']}.asknice.ly/api/v1"
+        self._base_url = f"https://{config['subdomain']}.asknice.ly/api/v1"
         self._api_key = config["api_key"]
         self._client = requests.Session()
 
     def fetch_unsubscribed(self):
-        url = f"{self._BASE_URL}/contacts/unsubscribed"
+        url = f"{self._base_url}/contacts/unsubscribed"
         params = {"X-apikey": self._api_key}
         return self._client.get(url, params=params).json()
-
 
     def fetch_responses(
         self, page: int, page_size: int, start_time_utc: str, end_time_utc: str
     ) -> dict:
         start_time_unix = int(strptime_to_utc(start_time_utc).timestamp())
         end_time_unix = int(strptime_to_utc(end_time_utc).timestamp())
-        url = f"{self._BASE_URL}/responses/asc/{page_size}/{page}/{start_time_unix}/json/0"
+        url = f"{self._base_url}/responses/asc/{page_size}/{page}/{start_time_unix}/json/0"
         params = {"X-apikey": self._api_key}
         return self._client.get(url, params=params).json()
 
     def fetch_sent_statistics(self, rolling_history: int) -> dict:
-        url = f"{self._BASE_URL}/sentstats/{rolling_history}"
+        url = f"{self._base_url}/sentstats/{rolling_history}"
         params = {"X-apikey": self._api_key}
         return self._client.get(url, params=params).json()
 
     def fetch_historical_stats(self, date: str) -> dict:
-        url = f"{self._BASE_URL}/stats"
-        date_list = date.split('-')
+        url = f"{self._base_url}/stats"
+        date_list = date.split("-")
         params = {
             "X-apikey": self._api_key,
             "year": date_list[0],
             "month": date_list[1],
-            "day": date_list[2]
+            "day": date_list[2],
         }
         return self._client.get(url, params=params).json()

--- a/tap_ask_nicely/schemas/historical_stats.json
+++ b/tap_ask_nicely/schemas/historical_stats.json
@@ -1,0 +1,60 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "year": {
+      "type": ["null", "string"]
+    },
+    "month": {
+      "type": ["null", "string"]
+    },
+    "day": {
+      "type": ["null", "string"]
+    },
+    "weekday": {
+      "type": ["null", "string"]
+    },
+    "sent": {
+      "type": ["null", "string"]
+    },
+    "delivered": {
+      "type": ["null", "string"]
+    },
+    "opened": {
+      "type": ["null", "string"]
+    },
+    "responded": {
+      "type": ["null", "string"]
+    },
+    "promoters": {
+      "type": ["null", "string"]
+    },
+    "passives": {
+      "type": ["null", "string"]
+    },
+    "detractors": {
+      "type": ["null", "string"]
+    },
+    "nps": {
+      "type": ["null", "string"]
+    },
+    "comments": {
+      "type": ["null", "string"]
+    },
+    "comment_length": {
+      "type": ["null", "string"]
+    },
+    "comment_responded_percent": {
+      "type": ["null", "string"]
+    },
+    "surveys_responded_percent": {
+      "type": ["null", "string"]
+    },
+    "surveys_delivered_responded_percent": {
+      "type": ["null", "string"]
+    },
+    "surveys_opened_responded_percent": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/tap_ask_nicely/schemas/sent_statistics.json
+++ b/tap_ask_nicely/schemas/sent_statistics.json
@@ -1,0 +1,33 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": false,
+  "properties": {
+    "nps": {
+      "type": ["null", "number"]
+    },
+    "sent": {
+      "type": ["null", "integer"]
+    },
+    "delivered": {
+      "type": ["null", "integer"]
+    },
+    "opened": {
+      "type": ["null", "integer"]
+    },
+    "responded": {
+      "type": ["null", "integer"]
+    },
+    "promoters": {
+      "type": ["null", "integer"]
+    },
+    "passives": {
+      "type": ["null", "integer"]
+    },
+    "detractors": {
+      "type": ["null", "integer"]
+    },
+    "responserate": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/tap_ask_nicely/sync.py
+++ b/tap_ask_nicely/sync.py
@@ -27,7 +27,7 @@ def sync(config, state, catalog):
             record_count = 0
 
             tap_stream_id = stream.tap_stream_id
-            stream_obj = STREAMS[tap_stream_id](client, state)
+            stream_obj = STREAMS[tap_stream_id](client, state, config)
             replication_key = stream_obj.replication_key
             stream_schema = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)

--- a/tap_ask_nicely/sync.py
+++ b/tap_ask_nicely/sync.py
@@ -57,7 +57,7 @@ def sync(config, state, catalog):
                     total_records += 1
 
                 if replication_key != "":
-                    state = singer.write_bookmark()(
+                    state = singer.write_bookmark(
                         state, tap_stream_id, replication_key, record[replication_key]
                     )
                     singer.write_state(state, tap_stream_id)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -65,3 +65,21 @@ def test_fetch_responses():
         assert "workflow_email_alert_c" in response
         assert "dashboard" in response
         assert "email_token" in response
+
+
+@pytest.mark.vcr()
+def test_fetch_sent_statistics():
+    client = AskNicelyClient(config)
+    rolling_day = 30 # 30 is default
+
+    sent_stats = client.fetch_sent_statistics(rolling_history=rolling_day)
+    assert "nps" in sent_stats
+    assert "sent" in sent_stats
+    assert "delivered" in sent_stats
+    assert "opened" in sent_stats
+    assert "responded" in sent_stats
+    assert "promoters" in sent_stats
+    assert "passives" in sent_stats
+    assert "detractors" in sent_stats
+    assert "responserate" in sent_stats
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -83,3 +83,29 @@ def test_fetch_sent_statistics():
     assert "detractors" in sent_stats
     assert "responserate" in sent_stats
 
+
+@pytest.mark.vcr()
+def test_fetch_historical_stats():
+    client = AskNicelyClient(config)
+    date = "2020-01-01"
+
+    historical_stats = client.fetch_historical_stats(date=date)['data'][0]
+    assert "year" in historical_stats
+    assert "month" in historical_stats
+    assert "day" in historical_stats
+    assert "weekday" in historical_stats
+    assert "sent" in historical_stats
+    assert "delivered" in historical_stats
+    assert "opened" in historical_stats
+    assert "responded" in historical_stats
+    assert "promoters" in historical_stats
+    assert "passives" in historical_stats
+    assert "detractors" in historical_stats
+    assert "nps" in historical_stats
+    assert "comments" in historical_stats
+    assert "comment_length" in historical_stats
+    assert "comment_responded_percent" in historical_stats
+    assert "surveys_responded_percent" in historical_stats
+    assert "surveys_delivered_responded_percent" in historical_stats
+    assert "surveys_opened_responded_percent" in historical_stats
+

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from dotenv import load_dotenv
-from tap_ask_nicely.streams import Response, Unsubscribed
+from tap_ask_nicely.streams import Response, SentStatistics, Unsubscribed
 from tap_ask_nicely.client import AskNicelyClient
 import singer
 import singer.utils as utils
@@ -30,7 +30,7 @@ def vcr_responses_ignore_end_time_utc(r1, r2):
 
 @pytest.mark.vcr()
 def test_unsubscribed():
-    stream = Unsubscribed(client=client, state={})
+    stream = Unsubscribed(client=client, state={}, config=config)
 
     unsubscribed_data = stream.sync()
     for unsubscribed in unsubscribed_data:
@@ -43,7 +43,7 @@ def test_unsubscribed():
 
 @pytest.mark.vcr()
 def test_response_stream_sync():
-    stream = Response(client=client, state={})
+    stream = Response(client=client, state={}, config=config)
 
     response_stream = stream.sync()
     for record in response_stream:
@@ -81,3 +81,19 @@ def test_response_stream_sync():
         assert "dashboard" in record
         assert "email_token" in record
 
+
+@pytest.mark.vcr()
+def test_sent_statistics():
+    stream = SentStatistics(client=client, state={}, config=config)
+
+    sent_stats = stream.sync()
+    for sent_stat in sent_stats:
+        assert "nps" in sent_stat
+        assert "sent" in sent_stat
+        assert "delivered" in sent_stat
+        assert "opened" in sent_stat
+        assert "responded" in sent_stat
+        assert "promoters" in sent_stat
+        assert "passives" in sent_stat
+        assert "detractors" in sent_stat
+        assert "responserate" in sent_stat


### PR DESCRIPTION
# Description :: Sent Statistics and Historical Stats

**Sent Statistics** - Full Table sync - Endpoint only returns a calculation based on stats in X number of days from the call date back.  This means that there is no historical data to pull.  This defaults to `1` but can be adjusted in the config using the key: `sent_statistics_days`

**Historical Stats** - Incremental sync - Endpoint record doesn't have a timestamp so incremental is done in the stream sync method itself with a `bookmark_key`.  The default start date is set in the config with the key: `start_date`.  One record per day.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [x] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes